### PR TITLE
Mis en place node 24 pour docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ test.geojson
 /.VSCodeCounter
 /docs/api/openapi-bundled.yaml
 /.vscode/chrome
+**/__pycache__

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:24
 WORKDIR /app
 COPY package*.json ./
 # Update npm to the latest version

--- a/serveur/Dockerfile
+++ b/serveur/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Base ----
-FROM node:20
+FROM node:24
 
 # ---- System dependencies ----
 RUN apt-get update && apt-get install -y \

--- a/serveur/package.json
+++ b/serveur/package.json
@@ -8,6 +8,9 @@
         "build": "tsc",
         "start": "node dist/serveur.js"
     },
+    "engines":{
+        "node": ">=24"
+    },
     "dependencies": {
         "axios": "1.12.0",
         "cors": "2.8.5",
@@ -30,7 +33,7 @@
         "@types/geojson": "7946.0.15",
         "@types/leaflet": "1.9.16",
         "@types/multer": "^2.0.0",
-        "@types/node": "22.10.7",
+        "@types/node": "^24.12.2",
         "@types/pg": "8.11.10",
         "@types/stream-json": "^1.7.8",
         "@typescript-eslint/eslint-plugin": "8.20.0",


### PR DESCRIPTION
J'ai changé la version de node, fait un docker compose build et docker compose up sans problème apparent après avoir ouvert la page et cliqué à quelques endroits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base image from Node.js 20 to Node.js 24 for both client and server.
  * Bumped project Node runtime requirement to Node.js >=24.
  * Added ignore rule for Python bytecode caches to repository ignores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->