### PR TITLE
Add copy reg set

### DIFF
--- a/client/src/components/lists/TableListeEnsReg.tsx
+++ b/client/src/components/lists/TableListeEnsReg.tsx
@@ -147,7 +147,20 @@ const TableListeEnsReg: React.FC<TableEnteteEnsembleProps> = (props) => {
             Ensembles Règlements
             </Typography>
             
-            
+            <div style={{padding:10}}>
+                <Button
+                    onClick={()=>props.setDuplicationModalOpen(true)}
+                    variant='outlined'
+                    fullWidth={true}
+                    sx={{
+                        gap:2,
+                        padding:'10px',
+                        
+                    }}
+                >
+                Démarrer duplication Ens reg
+            </Button>
+            </div>
             <div style={{padding:10}}>
                 <Button
                     onClick={gestBoutonAjout}

--- a/client/src/components/modals/ModalDuplicationEnsReg.tsx
+++ b/client/src/components/modals/ModalDuplicationEnsReg.tsx
@@ -1,0 +1,163 @@
+/*
+Copyright (c) 2026 Paul Charbonneau
+
+Licensed under the MIT License.
+See the LICENSE file in the project root for license information.
+
+Modal to search, select and duplicate a regulation set relatively rapidly
+*/
+
+import { 
+    Box, 
+    Button,
+    Modal, 
+    Table, 
+    TableBody, 
+    TableCell, 
+    TableHead, 
+    TableRow, 
+} from "@mui/material";
+import { 
+    Dispatch, 
+    SetStateAction, 
+    useState 
+} from "react";
+import { 
+    ensemble_reglements_stationnement, 
+    entete_ensembles_reglement_stationnement 
+} from "../../types/DataTypes";
+import { serviceEnsemblesReglements } from "../../services";
+import RegSetSearchComponent from "../searchComponents/RegSetSearchComponent";
+import { useSearchParams } from "react-router";
+
+interface ModalDuplicationProps {
+    modalOpen: boolean,
+    setModalOpen: Dispatch<SetStateAction<boolean>>
+    setRegSetList:Dispatch<SetStateAction<entete_ensembles_reglement_stationnement[]>>
+    setRegSetCurrent:Dispatch<SetStateAction<ensemble_reglements_stationnement>>
+}
+
+export default function ModalDuplicationEnsReg(props: ModalDuplicationProps) {
+    
+    const [
+        searchResults,
+        setSearchRes
+    ]= useState<
+            entete_ensembles_reglement_stationnement[]
+            >([])
+    const [erSelect,setErSelect]=useState<number|null>(null)
+    const [searchParams, setSearchParams] = useSearchParams();
+
+   
+
+    function handleRegSetSelect(id_er:number){
+        setErSelect(id_er)
+    }
+
+    async function handleRegSetCopy(){
+        if(erSelect!==null){
+            const newRegSet = await serviceEnsemblesReglements.copyRegulationSet(erSelect)
+            if (newRegSet.success&&newRegSet.data){
+                searchParams.set('id_er', String(newRegSet.data.entete.id_er))
+                setSearchParams(searchParams)
+                handleClose()
+            }
+            else{
+                alert('erreur pendant la copie')
+            }
+        }
+    }
+    function handleClose(){
+        props.setModalOpen(false)
+        setErSelect(null)
+    }
+    return (
+        <Modal
+            open={props.modalOpen}
+            onClose={handleClose}
+        >
+            <Box
+                sx={{
+                   width: 500, // was 100px — likely too narrow
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    bgcolor: "background.paper",
+                    p: 3,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 2,
+                }}
+            >
+                <RegSetSearchComponent
+                    setRegSet={setSearchRes}
+                />
+                <Table
+                    stickyHeader
+                >
+                    <TableHead>
+                        <TableRow>
+                            <TableCell>
+                                Ens. reg
+                            </TableCell>
+                            <TableCell>
+                                Date début
+                            </TableCell>
+                            <TableCell>
+                                Date fin
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {searchResults.map((rs)=><TableRow
+                            onClick={()=>handleRegSetSelect(rs.id_er)}
+                            key={rs.id_er}
+                            sx={{
+                                cursor: "pointer",
+                                "&:hover": {
+                                    backgroundColor: "action.hover",
+                                },
+                                "&:focus": {
+                                    outline: "2px solid",
+                                },
+                                ...(erSelect === rs.id_er && {
+                                    backgroundColor: "action.selected",
+                                }),
+                            }}
+                            hover
+                            selected={erSelect===rs.id_er}
+                            tabIndex={0}
+                            role="button"
+                            aria-pressed={erSelect===rs.id_er}
+                            onKeyDown={(e)=>{
+                                if (e.key==='Enter'||e.key===' '){
+                                    e.preventDefault()
+                                    handleRegSetSelect(rs.id_er)
+                                }
+                            }}
+                        >
+                            <TableCell>
+                                {rs.description_er}
+                            </TableCell>
+                            <TableCell>
+                                {rs.date_debut_er===null?'Perp':rs.date_debut_er}
+                            </TableCell>
+                            <TableCell>
+                                {rs.date_fin_er===null?'En vig':rs.date_fin_er}
+                            </TableCell>
+                        </TableRow>)}
+                    </TableBody>
+                </Table>
+                {erSelect!==null?
+                <Button
+                    variant='outlined'
+                    color='primary'
+                    onClick={handleRegSetCopy}
+                >
+                    Copier l'ens reg. {`${erSelect}`}
+                </Button>:<></>}
+            </Box>
+        </Modal>
+    )
+}

--- a/client/src/components/searchComponents/RegSetSearchComponent.tsx
+++ b/client/src/components/searchComponents/RegSetSearchComponent.tsx
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2026 Paul Charbonneau
+
+Licensed under the MIT License.
+See the LICENSE file in the project root for license information.
+
+Component that is used to set search parameters for various regulation sets
+*/
+
+import { Button, FormControl, InputLabel, MenuItem, Select, TextField } from "@mui/material";
+import { Box } from "@mui/system";
+import { Dispatch, SetStateAction, useState } from "react";
+import { ensemble_reglements_stationnement, entete_ensembles_reglement_stationnement } from "../../types/DataTypes";
+import { serviceEnsemblesReglements } from "../../services/serviceEnsemblesReglements";
+
+interface RSSCInterface{
+    setRegSet:Dispatch<SetStateAction<entete_ensembles_reglement_stationnement[]>>
+}
+
+export default function RegSetSearchComponent(props:RSSCInterface){
+    const [descSearch, setDescSearch] = useState<string | null>(null);
+    const [startYear, setStartYear] = useState<number | null>(null);
+    const [endYear, setEndYear] = useState<number | null>(null);
+    const [startYearCard, setStartYearCard] = useState<'before' | 'after' | 'unused'>('unused');
+    const [endYearCard, setEndYearCard] = useState<'before' | 'after' | 'unused'>('unused');
+
+     function handleChangeInputs(newVal: string | number, target: string) {
+            if (target === 'desc_search' && typeof newVal === 'string') {
+                setDescSearch(newVal)
+            }
+            if (target === 'start_year' && typeof newVal === 'number') {
+                setStartYear(newVal)
+            }
+            if (target==='end_year'&& typeof newVal === 'number'){
+                setEndYear(newVal)
+            }
+            if (target==='start_year_card'&&(
+                    newVal==='unused'||
+                    newVal==='before'||
+                    newVal==='after')
+            ){
+                if (newVal==='unused'){
+                    setStartYear(null)
+                }else if (startYear===null && (newVal==='before'||newVal==='after')){
+                    setStartYear(1940)
+                }
+                setStartYearCard(newVal)
+            }
+            if (target==='end_year_card'&&(
+                    newVal==='unused'||
+                    newVal==='before'||
+                    newVal==='after')
+            ){
+                if (newVal==='unused'){
+                    setEndYear(null)
+                }else if (endYear===null && (newVal==='before'||newVal==='after')){
+                    setEndYear(2025)
+                }
+                setEndYearCard(newVal)
+            }
+        }
+    
+        async function handleRegSetSearch(){
+            let searchBody={}
+            if (descSearch!==''&&descSearch!==null){
+                searchBody={...searchBody,descriptionLike:descSearch}
+            }
+            if (startYearCard==='before'){
+                searchBody={...searchBody,dateDebutAvant:startYear}
+            }
+            if (startYearCard==='after'){
+    
+                searchBody={...searchBody,dateDebutApres:startYear}
+            }
+            if (endYearCard==='before'){
+                searchBody={...searchBody,dateFinAvant:endYear}
+            }
+            if (endYearCard==='after'){
+    
+                searchBody={...searchBody,dateFinApres:endYear}
+            }
+            try {
+                const ensregPos = await serviceEnsemblesReglements.chercheEntetesParPropriete(searchBody)
+                if (ensregPos.success===true){
+                    props.setRegSet(ensregPos.data)
+                }
+            } catch(err:any){
+                console.error(err.message)
+                alert('erreur en obtenant les ensembles de règlements ')
+            }
+        }
+    return(
+        <Box
+            sx={{
+                   width: 400, // was 100px — likely too narrow
+                    bgcolor: "background.paper",
+                    p: 3,
+                    gap: 2,
+                    flexDirection:'column',
+                    display: "flex",
+                }}
+        >
+            <TextField
+                    label="Recherche description"
+                    value={descSearch??''}
+                    onChange={(e) => handleChangeInputs(e.target.value, "desc_search")}
+                    fullWidth={true}
+                />
+                <FormControl
+                    fullWidth={true}
+                >
+                    <InputLabel>
+                        Opération année début
+                    </InputLabel>
+                <Select
+                    value={startYearCard}
+                    onChange={(e)=>handleChangeInputs(e.target.value,'start_year_card')}
+                    label='Opération année début'
+                    fullWidth={true}
+                >
+                    <MenuItem
+                        key={'unused'}
+                        value={'unused'}
+                    >
+                        Ne pas utiliser
+                    </MenuItem>
+                    <MenuItem
+                        key={'before'}
+                        value={'before'}
+                    >
+                        Avant
+                    </MenuItem>
+                    <MenuItem
+                        key={'after'}
+                        value={'after'}
+                    >
+                        Après
+                    </MenuItem>
+                </Select>
+                </FormControl>
+                <TextField
+                    type="number"
+                    label="Année début"
+                    disabled={startYearCard==='unused'}
+                    value={startYear??''}
+                    onChange={(e) => handleChangeInputs(Number(e.target.value), "start_year")}
+                    fullWidth={true}
+                />
+                <FormControl
+                fullWidth={true}
+                >
+                    <InputLabel>Opération année fin</InputLabel>
+                <Select
+                    value={endYearCard}
+                    onChange={(e)=>handleChangeInputs(e.target.value,'end_year_card')}
+                    label='Opération année fin'
+                    fullWidth={true}
+                >
+                    <MenuItem
+                        key={'unused'}
+                        value={'unused'}
+                    >
+                        Ne pas utiliser
+                    </MenuItem>
+                    <MenuItem
+                        key={'before'}
+                        value={'before'}
+                    >
+                        Avant
+                    </MenuItem>
+                    <MenuItem
+                        key={'after'}
+                        value={'after'}
+                    >
+                        Après
+                    </MenuItem>
+                </Select>
+                </FormControl>
+                <TextField
+                    disabled={endYearCard==='unused'}
+                    value={endYear??''}
+                    type="number"
+                    label="Année fin"
+                    onChange={(e) => handleChangeInputs(Number(e.target.value), "end_year")}
+                    fullWidth={true}
+                />
+                <Button
+                    variant='outlined'
+                    onClick={handleRegSetSearch}
+                    fullWidth={true}
+                >
+                    Initier recherche
+                </Button>
+        </Box>
+    )
+}

--- a/client/src/pages/EnsemblesReglements.tsx
+++ b/client/src/pages/EnsemblesReglements.tsx
@@ -20,6 +20,7 @@ import CreationAssociationCubfRegEnsReg from "../components/modals/CreationAssoc
 import './ensemblereg.css'
 import './common.css'
 import { serviceEnsemblesReglements } from "../services";
+import ModalDuplicationEnsReg from '../components/modals/ModalDuplicationEnsReg'
 /**
  * this is the main page item for the modification of regulation sets. There are 2 big panels 
  * and 2 modals as part of this page which handle the various interactions
@@ -49,6 +50,7 @@ const EnsemblesReglements: React.FC = () => {
     const [editedAssignId,setEditedAssignId] = useState<number>(-1);
     const [newAssignModalOpen,setNewAssignModalOpen] = useState<boolean>(false);
     const [AllRegHeaders,setAllRegHeaders] = useState<entete_reglement_stationnement[]>([]);
+    const [duplicateERsModalOpen,setDuplicateERsModalOpen]=useState<boolean>(false)
     const [searchParams] = useSearchParams();
     
     useEffect(() => {
@@ -56,11 +58,16 @@ const EnsemblesReglements: React.FC = () => {
         const fetchER=async(idER:number)=>{
             const [
                 responseAssoc,
-                reponseEntete] = await Promise.all([
+                reponseEntete,
+                reponseListe
+            ] = await Promise.all([
                     serviceEnsemblesReglements.chercheEnsembleReglementParId(idER),
-                    serviceEnsemblesReglements.chercheReglementsPourEnsReg(idER)]) 
+                    serviceEnsemblesReglements.chercheReglementsPourEnsReg(idER),
+                    serviceEnsemblesReglements.chercheTousEntetesEnsemblesReglements()
+                ]) 
             setFullRegSet(responseAssoc.data[0])
             setPertinentRegs(reponseEntete.data)
+            setRegSetHeaders(reponseListe.data)
         }
         
         const id_er = searchParams.get("id_er");
@@ -86,6 +93,7 @@ const EnsemblesReglements: React.FC = () => {
                     defEditionCorpsEnCours={setAssignEditFlag}
                     ancienEnsRegComplet={oldFullRegSet}
                     defAncienEnsRegComplet={setOldFullRegSet}
+                    setDuplicationModalOpen={setDuplicateERsModalOpen}
                 />
 
                 {/* The panel on the right for detailed edition of regulation set */}
@@ -127,6 +135,12 @@ const EnsemblesReglements: React.FC = () => {
                     defTousReglement={setAllRegHeaders}
                     reglementVisu={pertinentRegs}
                     defReglementVisu={setPertinentRegs}
+                />
+                <ModalDuplicationEnsReg
+                    modalOpen={duplicateERsModalOpen}
+                    setModalOpen={setDuplicateERsModalOpen}
+                    setRegSetCurrent={setFullRegSet}
+                    setRegSetList={setRegSetHeaders}
                 />
             </div>
         </div>

--- a/client/src/services/serviceEnsemblesReglements.ts
+++ b/client/src/services/serviceEnsemblesReglements.ts
@@ -1,10 +1,42 @@
+/*
+Copyright (c) 2026 Paul Charbonneau
+
+Licensed under the MIT License.
+See the LICENSE file in the project root for license information.
+ 
+Service that launches queries to the backend to retrieve data
+*/
+
+
+
 import axios,{ AxiosResponse } from 'axios';
-import {ReponseEnteteEnsembleReglementStationnement,ReponseEnsembleReglementComplet, ReponseEntetesEnsemblesReglement, ReponseEntetesReglements, ReponseComboERsRoleFoncier, ReponseAssociationEnsembleReglement,ReponseUnitesGraph, ReponseDataGraphique} from '../types/serviceTypes';
+import {
+    ReponseEnteteEnsembleReglementStationnement,
+    ReponseEnsembleReglementComplet, 
+    ReponseEntetesEnsemblesReglement, 
+    ReponseEntetesReglements, 
+    ReponseComboERsRoleFoncier, 
+    ReponseAssociationEnsembleReglement,
+    ReponseUnitesGraph, 
+    ReponseDataGraphique, 
+    ApiResponse
+} from '../types/serviceTypes';
 import api from './api';
-import { association_util_reglement, entete_ensembles_reglement_stationnement, ProprietesRequetesER } from '../types/DataTypes';
+import { 
+    association_util_reglement, 
+    ensemble_reglements_stationnement, 
+    entete_ensembles_reglement_stationnement, 
+    ProprietesRequetesER 
+} from '../types/DataTypes';
 
-
+/**
+ * 
+ */
 class ServiceEnsemblesReglements {
+    /**
+     * basic get function that returns all the available datasets
+     * @returns all the available regulations sets in the database
+     */
     async chercheTousEntetesEnsemblesReglements():Promise<ReponseEntetesEnsemblesReglement> {
         try {
             const response: AxiosResponse<ReponseEntetesEnsemblesReglement> = await api.get(`/ens-reg/entete`);
@@ -22,6 +54,17 @@ class ServiceEnsemblesReglements {
         }
     } 
 
+    /**
+     * function to query backend for relevant regulation sets
+     * @param paramsRequetes object with following fields: 
+     *      dateDebutAvant?:number|null, 
+     *      dateDebutApres?:number|null, 
+     *      dateFinAvant?:number|null,  
+     *      dateFinApres?:number|null, 
+     *      descriptionLike?:string,        
+     *      idER?:number|number[]
+     * @returns an array of regulation set headers
+     */
     async chercheEntetesParPropriete(paramsRequetes:ProprietesRequetesER):Promise<ReponseEntetesEnsemblesReglement>{
         try {
             let query:string = `/ens-reg/entete`
@@ -291,6 +334,23 @@ class ServiceEnsemblesReglements {
                 console.error('Unexpected Error:', error);
             }
             throw error; // Re-throw if necessary
+        }
+    }
+
+    async copyRegulationSet(regSetToCopy:number){
+        try{
+            const response:AxiosResponse<ApiResponse<ensemble_reglements_stationnement>> = await api.post(`/ens-reg/copy/${regSetToCopy}`)
+            const data_res = response.data.data;
+            return{success:response.data.success,data:data_res};
+        }catch(error:any){
+            if (axios.isAxiosError(error)) {
+                console.error('Axios Error:', error.response?.data);
+                console.error('Axios Error Status:', error.response?.status);
+                console.error('Axios Error Data:', error.response?.data);
+            } else {
+                console.error('Unexpected Error:', error);
+            }
+            throw error
         }
     }
 }

--- a/client/src/types/InterfaceTypes.d.ts
+++ b/client/src/types/InterfaceTypes.d.ts
@@ -534,6 +534,7 @@ export interface TableEnteteEnsembleProps{
     defEditionCorpsEnCours:React.Dispatch<SetStateAction<boolean>>,
     ancienEnsRegComplet:ensemble_reglements_stationnement,
     defAncienEnsRegComplet:React.Dispatch<SetStateAction<ensemble_reglements_stationnement>>
+    setDuplicationModalOpen:Dispatch<SetStateAction<boolean>>
 }
 
 export interface TableVisModEnsRegProps{

--- a/serveur/src/api/controllers/ensemblesReglements.controllers.ts
+++ b/serveur/src/api/controllers/ensemblesReglements.controllers.ts
@@ -16,6 +16,7 @@ import {
 import { ParamsTerritoire } from "@localTypes/historique.types";
 import { ParamsRole } from "@localTypes/role.types";
 import { 
+    copyRegSetServ,
     deleteRegSetAssocServ, 
     deleteRegSetServ, 
     getChartInfoServ, 
@@ -31,13 +32,18 @@ import {
 } from "../services/ensembleReglements.services";
 import  { RequestHandler, Response, Request, NextFunction } from "express";
 
+
 /**
  * controller that gets relevant reg set headers based on query parameters
  * @param req request format from express
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const obtiensEntetesEnsemblesReglements: RequestHandler = async (req: Request, res: Response,next:NextFunction): Promise<void> => {
+export const obtiensEntetesEnsemblesReglements: RequestHandler = async (
+    req: Request, 
+    res: Response, 
+    next:NextFunction
+): Promise<void> => {
     console.log('Serveur - Obtention entetes ensembles reglements')
     try {
         const { 
@@ -78,7 +84,11 @@ export const obtiensEntetesEnsemblesReglements: RequestHandler = async (req: Req
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const obtiensEnsembleReglementCompletParId: RequestHandler = async (req: Request, res: Response, next:NextFunction): Promise<void> => {
+export const obtiensEnsembleReglementCompletParId: RequestHandler = async (
+    req: Request, 
+    res: Response, 
+    next:NextFunction
+): Promise<void> => {
     console.log('Serveur - Obtention ensembles reglements complets')
     try {
         const { id } = req.validated?.params as {id:number[]};
@@ -99,7 +109,11 @@ export const obtiensEnsembleReglementCompletParId: RequestHandler = async (req: 
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const obtiensReglementsPourEnsReg: RequestHandler = async (req:Request, res:Response,next): Promise<void> => {
+export const obtiensReglementsPourEnsReg: RequestHandler = async (
+    req:Request, 
+    res:Response, 
+    next: NextFunction
+): Promise<void> => {
     console.log('Serveur - Obtention entetes de reglements associés à un ensemble de règlements')
     try {
         const { id } = req.validated?.params as {id:number};
@@ -119,7 +133,11 @@ export const obtiensReglementsPourEnsReg: RequestHandler = async (req:Request, r
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const obtiensEntetesParTerritoire: RequestHandler<ParamsTerritoire> = async (req:Request, res:Response, next:NextFunction): Promise<void> => {
+export const obtiensEntetesParTerritoire: RequestHandler<ParamsTerritoire> = async (
+    req:Request, 
+    res:Response, 
+    next:NextFunction
+): Promise<void> => {
     console.log('Serveur - Obtention entete reglement par territoire')
 
     try {
@@ -139,7 +157,11 @@ export const obtiensEntetesParTerritoire: RequestHandler<ParamsTerritoire> = asy
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const obtiensEnsRegCompletParRole: RequestHandler<ParamsRole> = async (req:Request, res:Response, next:NextFunction): Promise<void> => {
+export const obtiensEnsRegCompletParRole: RequestHandler<ParamsRole> = async (
+    req:Request, 
+    res:Response, 
+    next:NextFunction
+): Promise<void> => {
     console.log('obtention ens-reg par role - Implémentation incomplète')
 
     try {
@@ -159,7 +181,11 @@ export const obtiensEnsRegCompletParRole: RequestHandler<ParamsRole> = async (re
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const nouvelleEnteteEnsembleReglement: RequestHandler = async (req, res, next): Promise<void> => {
+export const nouvelleEnteteEnsembleReglement: RequestHandler = async (
+    req:Request, 
+    res:Response, 
+    next:NextFunction
+): Promise<void> => {
     console.log('Sauvegarde nouvelle entete ensemble reg')
     try {
         const { 
@@ -189,7 +215,11 @@ export const nouvelleEnteteEnsembleReglement: RequestHandler = async (req, res, 
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const supprimeEnsembleReglement: RequestHandler<ParamsEnsReg> = async (req, res,next) => {
+export const supprimeEnsembleReglement: RequestHandler<ParamsEnsReg> = async (
+    req: Request, 
+    res: Response, 
+    next: NextFunction
+):Promise<void> => {
     console.log('Sauvegarde nouvelle entete ensemble reg')
     try {
         const { id } = req.validated?.params as {id:number};
@@ -209,7 +239,11 @@ export const supprimeEnsembleReglement: RequestHandler<ParamsEnsReg> = async (re
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const modifieEnteteEnsembleReglement: RequestHandler<ParamsEnsReg> = async (req, res,next ) => {
+export const modifieEnteteEnsembleReglement: RequestHandler<ParamsEnsReg> = async (
+    req:Request, 
+    res:Response, 
+    next: NextFunction 
+):Promise<void> => {
 
     try {
         const { id } = req.validated?.params as {id:number}
@@ -238,7 +272,11 @@ export const modifieEnteteEnsembleReglement: RequestHandler<ParamsEnsReg> = asyn
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const nouvelleAssociationEnsembleReglement: RequestHandler = async (req, res,next) => {
+export const nouvelleAssociationEnsembleReglement: RequestHandler = async (
+    req: Request, 
+    res: Response, 
+    next: NextFunction
+):Promise<void> => {
     console.log('Sauvegarde nouvelle association ensemble reg')
     try {
         const { 
@@ -267,7 +305,11 @@ export const nouvelleAssociationEnsembleReglement: RequestHandler = async (req, 
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const modifieAssocEnsembleReglement: RequestHandler<ParamsEnsReg> = async (req, res,next) => {
+export const modifieAssocEnsembleReglement: RequestHandler<ParamsEnsReg> = async (
+    req: Request, 
+    res: Response, 
+    next: NextFunction
+):Promise<void> => {
     try {
 
         const { id } = req.validated?.params as {id:number};
@@ -297,7 +339,11 @@ export const modifieAssocEnsembleReglement: RequestHandler<ParamsEnsReg> = async
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const supprimeAssocEnsembleReglement: RequestHandler<ParamsAssocEnsReg> = async (req, res,next) => {
+export const supprimeAssocEnsembleReglement: RequestHandler<ParamsAssocEnsReg> = async (
+    req: Request, 
+    res: Response, 
+    next: NextFunction
+):Promise<void> => {
     console.log('Sauvegarde nouvelle entete ensemble reg')
     try {
         const { id } = req.validated?.params as {id:number};
@@ -320,7 +366,11 @@ export const supprimeAssocEnsembleReglement: RequestHandler<ParamsAssocEnsReg> =
  * @param res response format form express
  * @param next next function execute in the express stack
  */
-export const infoPourGraphiques: RequestHandler = async (req, res,next ) => {
+export const infoPourGraphiques: RequestHandler = async (
+    req: Request, 
+    res: Response, 
+    next: NextFunction 
+) => {
 
     console.log('Getting information for graphs')
     try {
@@ -337,5 +387,33 @@ export const infoPourGraphiques: RequestHandler = async (req, res,next ) => {
     }
     
 };
+/**
+ * Controller used to copy regulation sets summarily. points to
+ * relevant service
+ * @param req request format from express. The expected data is checked through the
+ * validator and contains the id of the regulation set to copy see the router to dig 
+ * through what input is expected
+ * @param res response format form express. the body is specified based the return of
+ * copyRegSetServ which is a complete regulation set (header, associations and land uses)
+ * @param next next function execute in the express stack
+ */
+export const createRegSetCopy:RequestHandler=async (
+    req:Request, 
+    res:Response, 
+    next:NextFunction
+):Promise<void>=>{
+    try{
 
-
+        const {id}=req.validated?.params as {id:number};
+        const out = await copyRegSetServ(id)
+        if (out.success===true){
+            res.status(200).json(out)
+        } else {
+            console.error(`Copying reg set ${id} failed. Error message: ${out.message}`)
+            res.status(500).json(out)
+        }
+    } catch(err:any) {
+        console.error('Error',err.message)
+        res.status(500).json({success:false,message:err.message})
+    }
+}

--- a/serveur/src/api/repositories/ensembleReglements.repositories.ts
+++ b/serveur/src/api/repositories/ensembleReglements.repositories.ts
@@ -597,3 +597,75 @@ export function RunJoinQueriesToPythonOutputRepo(
     }));
     return output
 }
+/**
+ * Copies the header of the parking regulation set
+ * @param client pg pool client to use for the transaction
+ * @param idToCopy the identifier of the regulation set to copy
+ * @returns the newly created header
+ */
+export async function RunDuplicateRegSetHeaderRepo(
+    client: PoolClient, 
+    idToCopy: number
+):Promise<DbEnteteEnsembleReglement> {
+    const query = `
+        INSERT INTO public.ensembles_reglements_stat(
+            description_er,
+            date_debut_er,
+            date_fin_er
+        )
+        SELECT
+            CONCAT(description_er, ' - copie') AS description_er,
+            date_debut_er,
+            date_fin_er
+        FROM ensembles_reglements_stat
+        WHERE id_er = $1
+        RETURNING *;
+    `;
+    const resultAssoc = await client.query<DbEnteteEnsembleReglement>(query, [idToCopy]);
+    return resultAssoc.rows[0]
+}
+/**
+ * copies the associations of the copied reg set but changes the identifier
+ * @param client a pg poolClient to use to perform the operation
+ * @param idToCopy id of the reg set to copy
+ * @param newId id of the newly created reg set
+ * @returns the newly create assignments
+ */
+export async function RunDuplicateRegSetAssocRepo(
+    client:PoolClient,
+    idToCopy:number,
+    newId:number
+):Promise<DbAssociationReglementUtilSol[]>{
+    const query=`
+        With inserted as(
+        INSERT INTO public.association_er_reg_stat(id_er,cubf,id_reg_stat)
+        SELECT
+            $1 as id_er,
+            cubf,
+            id_reg_stat
+        from public.association_er_reg_stat
+        where id_er=$2
+        RETURNING * )
+        Select * from inserted
+        order by cubf::text asc;
+      `;
+    const resultAssoc = await client.query<DbAssociationReglementUtilSol>(query, [newId,idToCopy]);
+    return resultAssoc.rows
+}
+/**
+ * runs the query used to obtain the data
+ * @param client the pg pool client to use to run the queries
+ * @returns the entire land use table which is an id (cubf) and 
+ * a description
+ */
+export async function RunGetAllLandUsesQuery(
+    client:PoolClient
+):Promise<DbUtilisationSol[]>{
+    const query_3 = `
+            SELECT *
+            FROM public.cubf
+            ORDER BY cubf ASC
+          `
+    const resultUtilSol = await client.query<DbUtilisationSol>(query_3);
+    return resultUtilSol.rows
+}

--- a/serveur/src/api/routes/ensemblesReglements.ts
+++ b/serveur/src/api/routes/ensemblesReglements.ts
@@ -10,6 +10,7 @@ This is the router which requests the correct handler/controller based on the en
 import { Router } from 'express';
 
 import {
+    createRegSetCopy,
     infoPourGraphiques,
     modifieAssocEnsembleReglement,
     modifieEnteteEnsembleReglement,
@@ -61,5 +62,6 @@ export const creationRouteurEnsemblesReglements = (): Router => {
     router.get('/entete-par-territoire/:id',validateIncomingQueryInputs(DeleteItemsSchema), obtiensEntetesParTerritoire)
     router.get('/par-role/:ids', validateIncomingQueryInputs(GetRegSetsByTaxIdSchema),obtiensEnsRegCompletParRole)
     router.post('/informations-pour-graphique',validateIncomingQueryInputs(GetInfoForChartsSchema), infoPourGraphiques)
+    router.post('/copy/:id',validateIncomingQueryInputs(DeleteItemsSchema),createRegSetCopy)
     return router;
 };

--- a/serveur/src/api/services/ensembleReglements.services.ts
+++ b/serveur/src/api/services/ensembleReglements.services.ts
@@ -14,7 +14,8 @@ import {
     DbEnteteEnsembleReglement 
 } from '@localTypes/ensembleReglements.types'
 import pool from '../../db/createPool'
-import { RunChartsInfoPythonRepo, RunCreateNewRegSetHeaderRepo, RunCreateRegSetAssocRepo, RunDeleteRegSetAssocRepo, RunDeleteRegSetRepo, RunGetAssociatedInformationRepo, RunGetRegSetByTaxDataRepo, RunGetRegSetHeadersFromTerritoryRepo, RunJoinQueriesToPythonOutputRepo, RunModifyRegSetAssocRepo, parsePythonOuputJSONRepo, RunGetRegsForRegSetRepo, RunObtainRegSetHeadersQueriesRepo, RunObtainSpecificRegSetQueriesRepo, RunUpdateRegSetRepo } from '../repositories/ensembleReglements.repositories'
+import { RunChartsInfoPythonRepo, RunCreateNewRegSetHeaderRepo, RunCreateRegSetAssocRepo, RunDeleteRegSetAssocRepo, RunDeleteRegSetRepo, RunGetAssociatedInformationRepo, RunGetRegSetByTaxDataRepo, RunGetRegSetHeadersFromTerritoryRepo, RunJoinQueriesToPythonOutputRepo, RunModifyRegSetAssocRepo, parsePythonOuputJSONRepo, RunGetRegsForRegSetRepo, RunObtainRegSetHeadersQueriesRepo, RunObtainSpecificRegSetQueriesRepo, RunUpdateRegSetRepo, RunDuplicateRegSetHeaderRepo, RunDuplicateRegSetAssocRepo, RunGetAllLandUsesQuery } from '../repositories/ensembleReglements.repositories'
+import { ApiResponse, DbUtilisationSol } from '@localTypes'
 
 
 /**
@@ -314,5 +315,67 @@ export async function getChartInfoServ(string_in:string){
         if(client){
             await client.release()
         }
+    }
+}
+
+/**
+ * this service the business logic and opens the pool client required 
+ * to complete the copy operation
+ * @param oldId the reg set id for the thing we re trying to copy
+ * @returns the full copied regulation set id and a success flag
+ */
+export async function copyRegSetServ(
+    oldId:number
+):Promise<
+    ApiResponse<{
+        entete:DbEnteteEnsembleReglement,
+        assoc_util_reg:DbAssociationReglementUtilSol[]
+        table_util_sol:DbUtilisationSol[]
+    }>>
+{
+    let client;
+    try {
+        client = await pool.connect();
+        await client.query('BEGIN');
+
+        const newHeader = await RunDuplicateRegSetHeaderRepo(client, oldId);
+        if (!newHeader) {
+            await client.query('ROLLBACK')
+            return{success:false,message:`regulation set ${oldId} not found`}
+        }
+        const newId = newHeader.id_er;
+        const newAssocs = await RunDuplicateRegSetAssocRepo(
+            client,
+            oldId,
+            newId
+        );
+
+        const landUse = await RunGetAllLandUsesQuery(client);
+
+        const returnData = {
+            entete: newHeader,
+            assoc_util_reg: newAssocs,
+            table_util_sol: landUse
+        };
+
+        await client.query('COMMIT');
+
+        return {
+            success: true,
+            data: returnData
+        };
+
+    } catch (error:any) {
+        if (client) {
+            await client.query('ROLLBACK');
+        }
+        console.log('Error',error.message)
+        return {
+            success:false,
+            message:'error while duplicating reg set'
+        };
+
+    } finally {
+        client?.release();
     }
 }


### PR DESCRIPTION
This is the fourth change to implement the copy reg set functionality that actually does the thing. It is set up in two commits the first is the backend changes and the second is the frontend changes. 

the backend changes add the endpoint and the validator, add the relevant controller service and repository required to create the copy. The copy is implemented within a transaction so if one of the 2 queries fails, a rollback is thrown. 

on the frontend, basically we added a button, a modal to search for regulation sets, a handler function that calls the service and a function in the service to tell the backend to run the copy.

This needs the reorganized frontend and backend and frontend fixes to work so merge those in first

Review and approve #112  #113   and  #117 first

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to duplicate existing regulation sets from the regulation-sets page.
  * Added search filters for finding regulation sets by description and date range.
  * Duplicated sets retain their dates and associated land-use information, with “- copie” added to the description.
  * Added a selection window with keyboard and mouse support for choosing a regulation set to duplicate.
  * Added confirmation, success, and error handling for duplication actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->