### PR TITLE
Fix issues stemming from react-router update

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,6 +28,7 @@
         "react-leaflet": "^5.0.0",
         "react-resizable": "^3.0.5",
         "react-router": "^8.3.0",
+        "react-router-dom": "^7.18.2",
         "react-scripts": "^5.0.1",
         "react-spinners": "^0.17.0"
       },
@@ -5940,6 +5941,19 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cookie-es": {
       "version": "3.1.1",
@@ -13413,6 +13427,44 @@
         }
       }
     },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -14246,6 +14298,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "react-leaflet": "^5.0.0",
     "react-resizable": "^3.0.5",
     "react-router": "^8.3.0",
+    "react-router-dom": "^7.18.2",
     "react-scripts": "^5.0.1",
     "react-spinners": "^0.17.0"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router';
+import {BrowserRouter as Router, Routes, Route, Navigate} from 'react-router-dom'
 import Histoire from './pages/Histoire';
 import VisualisationInventaire from './pages/VisualisationInventaire';
 import Reglements from './pages/Reglements';

--- a/client/src/components/ControlEnsRegTerr.tsx
+++ b/client/src/components/ControlEnsRegTerr.tsx
@@ -2,7 +2,7 @@ import React,{useState,useEffect} from 'react';
 import { EnsRegTerrControlProps } from '../types/InterfaceTypes';
 import { serviceEnsemblesReglements, serviceHistorique, serviceTerritoires } from '../services';
 import { serviceEnsRegTerr } from '../services/serviceEnsRegTerr';
-import { useSearchParams } from 'react-router';
+import { useSearchParams } from 'react-router-dom';
 
 
 const ControlEnsRegTerr:React.FC<EnsRegTerrControlProps> = (props:EnsRegTerrControlProps) =>{

--- a/client/src/components/MenuBar.tsx
+++ b/client/src/components/MenuBar.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { Link } from "react-router";
-import { FournisseurContexte,utiliserContexte } from '../contexte/ContexteImmobilisation';
+import React from 'react';
+import { utiliserContexte } from '../contexte/ContexteImmobilisation';
 import { donneesCarteDeFond } from '../types/ContextTypes';
 import SubMenuComponent from './SubMenuComponent';
-import { latLng, LatLng } from 'leaflet';
+
 const MenuBar: React.FC<{}> = () => {
 
     const contexte = utiliserContexte();

--- a/client/src/components/SubMenuComponent.tsx
+++ b/client/src/components/SubMenuComponent.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, } from "react-router";
+import { useNavigate, } from "react-router-dom";
 import { useState } from "react";
 import { SubMenuProps } from "../types/InterfaceTypes";
 import { FormControl,InputLabel,Select,MenuItem,SelectChangeEvent, Menu, Button } from "@mui/material";

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/client/src/pages/EnsemblesReglements.tsx
+++ b/client/src/pages/EnsemblesReglements.tsx
@@ -2,7 +2,7 @@ import MenuBar from "../components/MenuBar";
 import TableListeEnsReg from "../components/TableListeEnsReg";
 import TableVisModEnsReg from "../components/TableVisEnsReg";
 import { useState, useEffect, useRef } from "react";
-import {useSearchParams} from 'react-router'
+import {useSearchParams} from 'react-router-dom'
 import {  association_util_reglement, ensemble_reglements_stationnement, entete_reglement_stationnement } from "../types/DataTypes";
 import { entete_ensembles_reglement_stationnement } from "../types/DataTypes";
 import CreationAssociationCubfRegEnsReg from "../components/CreationAssociationCubfRegEnsReg";

--- a/client/src/pages/Reglements.tsx
+++ b/client/src/pages/Reglements.tsx
@@ -3,7 +3,7 @@ import TableEnteteReglements from "../components/TableEnteteReglements";
 import TableVisModReglement from "../components/tableVisReglement";
 import { useState, useEffect, useRef } from "react";
 import { entete_reglement_stationnement, definition_reglement_stationnement, reglement_complet } from "../types/DataTypes";
-import { useSearchParams } from "react-router";
+import { useSearchParams } from "react-router-dom";
 import './reg.css';
 import './common.css';
 import { serviceReglements } from "../services";


### PR DESCRIPTION
There appears to have been an issue when updating one of the modules in the stream of dependabot fixes, most likely the react-router update. As such when building the app recently, the app started throwing a bunch of errors arount importing items from react-router which appear to have moved to react-router-dom.

This commit aims to fix all the errors that have been flagged in the process.

In addition, noticed that the css imports were no longer working for whatever reason so add the global.d.ts in order to manage those imports

package.json
Addeed react-router-dom package

global.d.ts
New file to manage the imports of css correctly.

ControlEnsRegTerr
Changed imports to react-router-dom

MenuBar
Cleaned up unused imports. The Link import was flagging an error and I removed it because it was not being used

SubMenuComponent
Changed import to use react router dom on useNavigate

EnsemblesReglements
Changed import to react-router-dom

Reglements
Changed import to react-router-dom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated routing support to use the web application’s standard router package.
  * Preserved existing navigation and URL parameter behavior.

* **Bug Fixes**
  * Improved TypeScript support for importing CSS files, helping prevent related build and type-checking errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->