### PR TITLE
Fix build issues from react-router update

### DIFF
--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/client/src/services/serviceReglements.ts
+++ b/client/src/services/serviceReglements.ts
@@ -1,8 +1,14 @@
 import axios,{ AxiosResponse } from 'axios';
 import { definition_reglement_stationnement, entete_reglement_stationnement, parametres_requete_filtree_stationnement,  } from '../types/DataTypes';
-import { ReponseEntetesReglements, ReponseReglementComplet,ReponseDBInfoInventaireReglementManuel, ReponseEntetesEnsemblesReglement, ReponseOperationsReglements,ReponseUnitesReglements, ReponseLigneDefReglement, ReponseDataGraphique, ApiResponse} from '../types/serviceTypes';
-import api from './api';
-import { promises } from 'dns';
+import { 
+    ReponseEntetesReglements, 
+    ReponseReglementComplet,
+    ReponseOperationsReglements,
+    ReponseLigneDefReglement, 
+    ReponseDataGraphique, 
+    ApiResponse
+} from '../types/serviceTypes';
+import api from './api'; 
 
 class ServiceReglements {
     async chercheTousEntetesReglements():Promise<ReponseEntetesReglements> {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,7 @@
       "forceConsistentCasingInFileNames": true,
       "noFallthroughCasesInSwitch": true,
       "module": "esnext",
-      "moduleResolution": "node",
+      "moduleResolution": "bundler",
       "resolveJsonModule": true,
       "isolatedModules": true,
       "noEmit": true,


### PR DESCRIPTION
Appears that updating react-router broke something with how the legacy moduleResolution I was working with and in doing so it created issues.

In addition, css files were no longer importing correctly leading to some issues. Creating a fake module in order to import the css into the files correctly

Also had a dead import that appeared at some point which was not used so cleaned that up to avoid failures

tsconfig.json
Changed moduleResolution from deprecated node to bundler which requires no other changes

global.d.ts
CSS file imports in the pages files were failing. add the global.d.ts which then sets up a module with all the css files resolves the issue

serviceReglements.ts
Removed unused dns import which wasn't used at all. It was added a year ago (9c6fe0f) without being used. I suspect it got auto-completed by VSCode and slipped through. I don't know why it no longer work other than the dns package must have been removed from the package-lock by one of the dependabot  updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript configuration to support modern module resolution.
  * Added support for importing CSS files in TypeScript.
  * Cleaned up unused imports to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->